### PR TITLE
added alignToTerrainPoints

### DIFF
--- a/addons/main/CfgFunctions.hpp
+++ b/addons/main/CfgFunctions.hpp
@@ -1,8 +1,8 @@
 class CfgFunctions {
     class TerrainLib {
         class Terrain {
-            PATHTO_FNC(alignToTerrainPoints);
             PATHTO_FNC(addTerrainHeight);
+            PATHTO_FNC(alignPointsToGrid);
             PATHTO_FNC(nearestTerrainPoint);
             PATHTO_FNC(setTerrainHeight);
             PATHTO_FNC(getAreaTerrainGrid);

--- a/addons/main/CfgFunctions.hpp
+++ b/addons/main/CfgFunctions.hpp
@@ -1,6 +1,7 @@
 class CfgFunctions {
     class TerrainLib {
         class Terrain {
+            PATHTO_FNC(alignToTerrainPoints);
             PATHTO_FNC(addTerrainHeight);
             PATHTO_FNC(nearestTerrainPoint);
             PATHTO_FNC(setTerrainHeight);

--- a/addons/main/fnc_alignPointsToGrid.sqf
+++ b/addons/main/fnc_alignPointsToGrid.sqf
@@ -1,6 +1,6 @@
 #include "script_component.hpp"
 /* ----------------------------------------------------------------------------
-Function: TerrainLib_fnc_alignToTerrainPoints
+Function: TerrainLib_fnc_alignPointsToGrid
 
 Description:
     Given an Array of Positions and Heights, return the positions and heights that would result from the automatic aligning process in TerrainLib_fnc_setTerrainHeight
@@ -18,7 +18,7 @@ Examples:
         [1005, 1000, 25], 
         [1000, 1005, 25], 
         [1005, 1005, 25]
-    ]] call TerrainLib_fnc_alignToTerrainPoints;
+    ]] call TerrainLib_fnc_alignPointsToGrid;
     (end)
 
 Author:
@@ -30,11 +30,14 @@ params [
 
 
 private _positionsHM = createHashMap;
-
+getTerrainInfo params ["", "", "_cellSize", "_resolution", ""];
 {
-    private _pos = [_x] call TerrainLib_fnc_nearestTerrainPoint;
+    private _xy = _x select [0,2];
+    private _pos = _xy apply {
+        (round (_x/_cellsize))*_cellSize
+    };
     _pos set [2, _x#2];
-    _positionsHM set [[_pos#0, _pos#1], _pos];
+    _positionsHM set [_xy, _pos];
 } forEach _positionsAndHeights;
 
-values _positionsHM;
+values _positionsHM

--- a/addons/main/fnc_alignToTerrainPoints.sqf
+++ b/addons/main/fnc_alignToTerrainPoints.sqf
@@ -1,0 +1,40 @@
+#include "script_component.hpp"
+/* ----------------------------------------------------------------------------
+Function: TerrainLib_fnc_alignToTerrainPoints
+
+Description:
+    Given an Array of Positions and Heights, return the positions and heights that would result from the automatic aligning process in TerrainLib_fnc_setTerrainHeight
+
+Parameters:
+    _positionsAndHeights - array of [[x1,y1,z1], [x2,y2,z2]...]  [ARRAY]
+
+Returns:
+    Positions and Heights usable with lazy setTerrainHeight [ARRAY] 
+
+Examples:
+    (begin example)
+    [[
+        [1002.7, 1000, 25], 
+        [1005, 1000, 25], 
+        [1000, 1005, 25], 
+        [1005, 1005, 25]
+    ]] call TerrainLib_fnc_alignToTerrainPoints;
+    (end)
+
+Author:
+    EL_D148L0
+---------------------------------------------------------------------------- */
+params [
+    ["_positionsAndHeights", [], [[]]]
+];
+
+
+private _positionsHM = createHashMap;
+
+{
+    private _pos = [_x] call TerrainLib_fnc_nearestTerrainPoint;
+    _pos set [2, _x#2];
+    _positionsHM set [[_pos#0, _pos#1], _pos];
+} forEach _positionsAndHeights;
+
+values _positionsHM;


### PR DESCRIPTION
this function is useful in the terrainHeightChanged EH, because when you receive that EH, the passed positions could be not aligned to the terrain grid.
with this function the positions get aligned to the grid and duplicates that snap to the same point get removed the same way they are in setTerrainHeight.